### PR TITLE
Added asusctl support in waybar/powerprofile.sh for Asus users

### DIFF
--- a/waybar/scripts/powerprofile.sh
+++ b/waybar/scripts/powerprofile.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Get supported powerctl
 if command -v powerprofilesctl &>/dev/null; then
   powerctl="powerprofilesctl"
 elif command -v asusctl &>/dev/null; then

--- a/waybar/scripts/powerprofile.sh
+++ b/waybar/scripts/powerprofile.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Get supported powerctl
 if command -v powerprofilesctl &>/dev/null; then
   powerctl="powerprofilesctl"
 elif command -v asusctl &>/dev/null; then
@@ -11,17 +10,21 @@ fi
 
 # Get current power profile
 get_current_profile() {
-  if command -v powerprofilesctl &>/dev/null; then
+  case "$powerctl" in
+  "powerprofilesctl")
     powerprofilesctl get
-  elif command -v asusctl &>/dev/null; then
+    ;;
+  "asusctl")
     local current_mode=$(asusctl profile -p | awk '/^Active profile is /{print tolower($NF); exit}')
     if [ "$current_mode" = "quiet" ]; then
       current_mode="power-saver"
     fi
     echo "$current_mode"
-  else
+    ;;
+  *)
     echo "power-saver" # fallback
-  fi
+    ;;
+  esac
 }
 
 # Set power profile
@@ -44,7 +47,7 @@ set_profile() {
 # Toggle between profiles
 toggle_profile() {
   current=$(get_current_profile)
-  case $current in
+  case "$current" in
   "power-saver")
     set_profile "balanced"
     ;;

--- a/waybar/scripts/powerprofile.sh
+++ b/waybar/scripts/powerprofile.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
+# Get supported powerctl
+if command -v powerprofilesctl &>/dev/null; then
+  powerctl="powerprofilesctl"
+elif command -v asusctl &>/dev/null; then
+  powerctl="asusctl"
+else
+  powerctl=""
+fi
+
 # Get current power profile
 get_current_profile() {
   if command -v powerprofilesctl &>/dev/null; then
     powerprofilesctl get
+  elif command -v asusctl &>/dev/null; then
+    local current_mode=$(asusctl profile -p | awk '/^Active profile is /{print tolower($NF); exit}')
+    if [ "$current_mode" = "quiet" ]; then
+      current_mode="power-saver"
+    fi
+    echo "$current_mode"
   else
     echo "power-saver" # fallback
   fi
@@ -11,23 +26,19 @@ get_current_profile() {
 
 # Set power profile
 set_profile() {
-  case $1 in
-  "power-saver")
+  local mode="$1"
+  if [ "$powerctl" = "powerprofilesctl" ]; then
     if command -v powerprofilesctl &>/dev/null; then
-      powerprofilesctl set power-saver
+      powerprofilesctl set "$mode"
     fi
-    ;;
-  "balanced")
-    if command -v powerprofilesctl &>/dev/null; then
-      powerprofilesctl set balanced
+  elif [ "$powerctl" = "asusctl" ]; then
+    if [ "$1" = "power-saver" ]; then
+      mode="quiet"
     fi
-    ;;
-  "performance")
-    if command -v powerprofilesctl &>/dev/null; then
-      powerprofilesctl set performance
+    if command -v asusctl &>/dev/null; then
+      asusctl profile -P "$mode"
     fi
-    ;;
-  esac
+  fi
 }
 
 # Toggle between profiles
@@ -42,6 +53,9 @@ toggle_profile() {
     ;;
   "performance")
     set_profile "power-saver"
+    ;;
+  *)
+    set_profile "balanced"
     ;;
   esac
 }
@@ -63,7 +77,7 @@ display_profile() {
 }
 
 # Handle arguments
-case $1 in
+case "${1:-display}" in
 "toggle")
   toggle_profile
   display_profile

--- a/waybar/scripts/powerprofile.sh
+++ b/waybar/scripts/powerprofile.sh
@@ -16,7 +16,7 @@ get_current_profile() {
     powerprofilesctl get
     ;;
   "asusctl")
-    local current_mode=$(asusctl profile -p | awk '/^Active profile is /{print tolower($NF); exit}')
+    local current_mode=$(asusctl profile get | awk '/^Active profile: /{print tolower($NF); exit}')
     if [ "$current_mode" = "quiet" ]; then
       current_mode="power-saver"
     fi
@@ -40,7 +40,7 @@ set_profile() {
       mode="quiet"
     fi
     if command -v asusctl &>/dev/null; then
-      asusctl profile -P "$mode"
+      asusctl profile set "$mode"
     fi
   fi
 }


### PR DESCRIPTION
Hi, 

I've been trying your waybar configuration on my own Niri. It is beautiful, and helped me a lot, thank you!

For Asus laptop users, many prefers `asusctl` for power management, so I refactored `waybar/powerprofile.sh` to add support for `asusctl`.

The power icon on the left modules of waybar should work either with `powerprofilesctl` or `asusctl` by now.